### PR TITLE
Remove the jar file option

### DIFF
--- a/docker/java/docker-compose.web.yml
+++ b/docker/java/docker-compose.web.yml
@@ -1,3 +1,3 @@
 services:
   web:
-    command: ['java', '-cp', $SERVER_JAR_FILE, 'com.stripe.sample.Server']
+    command: ['java', '-cp', 'target/sample-jar-with-dependencies.jar', 'com.stripe.sample.Server']

--- a/helpers.sh
+++ b/helpers.sh
@@ -26,9 +26,8 @@ install_docker_compose_settings_for_integration() {
     export SAMPLE=${1}
     export SERVER_LANG=${2}
     export STATIC_DIR=${3}
-    export SERVER_JAR_FILE=${4}
 
-    variables='${SAMPLE}${SERVER_LANG}${STATIC_DIR}${SERVER_JAR_FILE}${STRIPE_WEBHOOK_SECRET}'
+    variables='${SAMPLE}${SERVER_LANG}${STATIC_DIR}${STRIPE_WEBHOOK_SECRET}'
     cat sample-ci/docker/docker-compose.base.yml | envsubst "$variables" > docker-compose.yml
     cat sample-ci/docker/${SERVER_LANG}/docker-compose.web.yml | envsubst "$variables" > docker-compose.override.yml
   )


### PR DESCRIPTION
Hi. After some conversations with CJ, we concluded that we can remove this option by using the same name (`sample-jar-with-dependencies.jar`) for jar files that use sample-ci. This PR removes the option. I will also change jar file names for each repository.