### PR TITLE
Revert "Revert "Remove the jar file option""

### DIFF
--- a/docker/java/docker-compose.web.yml
+++ b/docker/java/docker-compose.web.yml
@@ -1,3 +1,3 @@
 services:
   web:
-    command: ['java', '-cp', $SERVER_JAR_FILE, 'com.stripe.sample.Server']
+    command: ['java', '-cp', 'target/sample-jar-with-dependencies.jar', 'com.stripe.sample.Server']

--- a/helpers.sh
+++ b/helpers.sh
@@ -26,9 +26,8 @@ install_docker_compose_settings_for_integration() {
     export SAMPLE=${1}
     export SERVER_LANG=${2}
     export STATIC_DIR=${3}
-    export SERVER_JAR_FILE=${4}
 
-    variables='${SAMPLE}${SERVER_LANG}${STATIC_DIR}${SERVER_JAR_FILE}${STRIPE_WEBHOOK_SECRET}'
+    variables='${SAMPLE}${SERVER_LANG}${STATIC_DIR}${STRIPE_WEBHOOK_SECRET}'
     cat sample-ci/docker/docker-compose.base.yml | envsubst "$variables" > docker-compose.yml
     cat sample-ci/docker/${SERVER_LANG}/docker-compose.web.yml | envsubst "$variables" > docker-compose.override.yml
   )


### PR DESCRIPTION
I've investigated the failed CIs for the following pull requests.

* https://github.com/stripe-samples/subscription-use-cases/pull/82 ([CI](https://github.com/stripe-samples/subscription-use-cases/runs/1698504333?check_suite_focus=true))
* https://github.com/stripe-samples/checkout-single-subscription/pull/49 ([CI](https://github.com/stripe-samples/checkout-single-subscription/runs/1698500843?check_suite_focus=true))
* https://github.com/stripe-samples/checkout-one-time-payments/pull/55 ([CI](https://github.com/stripe-samples/checkout-one-time-payments/runs/1698498734?check_suite_focus=true))
* https://github.com/stripe-samples/accept-a-card-payment/pull/61 (CI haven't run yet with this branch)

As I mentioned on #4, currently, we cannot run CI on forked repositories, and perhaps that's the reason for these failures. I'd like to investigate that as a separate issue.

As for removing jar options, I assume that this and the other pull requests above will run without problems after merged. To make sure there are not any other major issues, I want to run the new CI on a topic branch of the upstream repository. Could you push [this temporary branch](https://github.com/stripe-samples/checkout-single-subscription/compare/master...hibariya:jar-verify) to stripe-samples/checkout-single-subscription? The branch will use this branch (`3-revert-2-jar`) as sample-ci.

```
# like this:
git remote add hibariya https://github.com/hibariya/checkout-single-subscription.git
git fetch hibariya
git push origin hibariya/jar-verify jar-verify
```