### PR TITLE
Run bundle-install on the runner in advance

### DIFF
--- a/helpers.sh
+++ b/helpers.sh
@@ -10,6 +10,7 @@ install_docker_compose_settings() {
 
   docker-compose run --entrypoint=/bin/sh runner -c true
   docker cp . $(docker-compose ps -qa runner | head -1):/work/
+  docker-compose run --rm runner bundle install -j4
 }
 
 configure_docker_compose_for_integration() {


### PR DESCRIPTION
https://github.com/stripe-samples/accept-a-card-payment/pull/81 needs this.

Some gems like Nokogiri take a longer time to install than building the web container. When [this bundle-install](https://github.com/stripe-samples/sample-ci/blob/fe5510363037041d41d1fdbc3642a91e4b6b9ea6/docker/runner/entrypoint.sh#L4) on the runner container is not finished, `docker-compose exec runner bundle exec rspec` will fail due to `Bundler::GemNotFound`.  To avoid it, I added the bundle-install explicitly so that the installation finishes in the earlier step.