### PR TITLE
Add ability to specify the server image

### DIFF
--- a/docker/docker-compose-v2.yml
+++ b/docker/docker-compose-v2.yml
@@ -1,0 +1,68 @@
+services:
+  runner:
+    image: ruby:3.0
+    working_dir: /work
+    init: true
+    entrypoint: ['/work/sample-ci/docker/runner/entrypoint.sh']
+    env_file: .env
+    environment:
+      - STRIPE_PUBLISHABLE_KEY=${STRIPE_PUBLISHABLE_KEY}
+      - STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY}
+      - SERVER_URL=${SERVER_URL:-http://web:4242}
+      - BUNDLE_JOBS=5
+    volumes:
+      - work:/work
+      - gem:/usr/local/bundle
+
+  stripe:
+    image: stripe/stripe-cli:v1.5.3
+    init: true
+    entrypoint: ['/bin/ash']
+    command: ['-c', '/bin/stripe --api-key=$STRIPE_SECRET_KEY listen --forward-to http://web:4242/webhook']
+    env_file: .env
+    environment:
+      - STRIPE_PUBLISHABLE_KEY=${STRIPE_PUBLISHABLE_KEY}
+      - STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY}
+
+  web:
+    image: "${SERVER_IMAGE}"
+    working_dir: /work/${SAMPLE}/server/${SERVER_TYPE}
+    init: true
+    entrypoint: ['/work/sample-ci/docker/${SERVER_TYPE}/entrypoint.sh']
+    ports: ['4242:4242']
+    env_file: .env
+    environment:
+      - STRIPE_PUBLISHABLE_KEY=${STRIPE_PUBLISHABLE_KEY}
+      - STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY}
+      - STRIPE_WEBHOOK_SECRET=${STRIPE_WEBHOOK_SECRET}
+      - STATIC_DIR=${STATIC_DIR}
+    volumes:
+      - work:/work
+      - gem:/usr/local/bundle
+
+  frontend:
+    profiles: ['frontend']
+    build:
+      context: .
+      dockerfile: sample-ci/docker/${CLIENT_TYPE}/Dockerfile
+    stdin_open: true
+    working_dir: /work/${SAMPLE}/client/${CLIENT_TYPE}
+    init: true
+    entrypoint: ['/work/sample-ci/docker/${CLIENT_TYPE}/entrypoint.sh']
+    ports: ['3000:3000']
+    environment:
+      - HOST=0.0.0.0
+      - DANGEROUSLY_DISABLE_HOST_CHECK=true
+    volumes:
+      - work:/work
+
+  selenium:
+    profiles: ['e2e', 'frontend']
+    image: selenium/standalone-chrome-debug:3.141
+    ports: ['5900:5900', '4444:4444']
+    environment:
+      - VNC_NO_PASSWORD='1'
+
+volumes:
+  work:
+  gem:

--- a/docker/dotnet/entrypoint.sh
+++ b/docker/dotnet/entrypoint.sh
@@ -1,7 +1,16 @@
 #!/bin/bash -e
 
+case $(dotnet --version) in
+  3.*)
+    framework_flags="--framework netcoreapp3.1"
+    ;;
+  5.*)
+    framework_flags="--framework net5.0"
+    ;;
+esac
+
 if [[ "$#" -eq "0" ]]; then
-  exec dotnet run --urls http://0.0.0.0:4242
+  exec dotnet run --urls http://0.0.0.0:4242 $framework_flags
 else
   exec "$@"
 fi

--- a/helpers.sh
+++ b/helpers.sh
@@ -35,10 +35,17 @@ install_docker_compose_settings_for_integration() {
     export SAMPLE=${1}
     export SERVER_TYPE=${2}
     export STATIC_DIR=${3}
+    export SERVER_IMAGE=${4}
     export CLIENT_TYPE=$(basename "$STATIC_DIR")
 
-    variables='${SAMPLE}${SERVER_TYPE}${STATIC_DIR}${CLIENT_TYPE}'
-    cat sample-ci/docker/docker-compose.yml | envsubst "$variables" > docker-compose.yml
+    if [[ -z "${SERVER_IMAGE}" ]]; then
+      compose_file=docker-compose.yml
+    else
+      compose_file=docker-compose-v2.yml
+    fi
+
+    variables='${SAMPLE}${SERVER_TYPE}${STATIC_DIR}${CLIENT_TYPE}${SERVER_IMAGE}'
+    cat sample-ci/docker/${compose_file} | envsubst "$variables" > docker-compose.yml
   )
 }
 


### PR DESCRIPTION
https://github.com/stripe-samples/accept-a-payment/pull/192 depends on this. Added the 4th argument to `install_docker_compose_settings_for_integration()`  to specify the Docker image for the server implementation. Made the entrypoint for dotnet support both 3.1 and 5.0 frameworks.