### PR TITLE
Fix the multiple-runtime support

### DIFF
--- a/docker/docker-compose-v2.yml
+++ b/docker/docker-compose-v2.yml
@@ -38,7 +38,6 @@ services:
       - STATIC_DIR=${STATIC_DIR}
     volumes:
       - work:/work
-      - gem:/usr/local/bundle
 
   frontend:
     profiles: ['frontend']

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   runner:
-    image: ruby:2.7.1
+    image: ruby:3.0
     working_dir: /work
     init: true
     entrypoint: ['/work/sample-ci/docker/runner/entrypoint.sh']

--- a/helpers.sh
+++ b/helpers.sh
@@ -17,10 +17,11 @@ configure_docker_compose_for_integration() {
   [[ "$1" = "main" ]] && sample="." || sample="$1"
   server_type=${2}
   static_dir=${3}
+  server_image=${4}
 
-  echo "### Configuring the settings for the integration; sample: ${sample}, server_type: ${server_type}, static_dir: ${static_dir}"
+  echo "### Configuring the settings for the integration; sample: ${sample}, server_type: ${server_type}, static_dir: ${static_dir}, server_image: ${server_image}"
 
-  install_docker_compose_settings_for_integration "$sample" "$server_type" "$static_dir"
+  install_docker_compose_settings_for_integration "$sample" "$server_type" "$static_dir" "$server_image"
 
   docker-compose stop web || true
   docker-compose build web


### PR DESCRIPTION
I noticed that all test jobs for one runtime are actually running with the same version. After a short investigation, it turned out that a couple of fixes are needed for the previous [PR](https://github.com/stripe-samples/sample-ci/pull/13) :pray:

1. The optional fourth parameter wasn't being passed correctly.
2. The Ruby version of the `runner` service should have been the same between `docker-compose.yml` and `docker-compose-v2.yml` so that the changes do not affect `install_docker_compose_settings()`.

Confirmed it works as we expect on https://github.com/hibariya/accept-a-payment/actions/runs/1130268909

Without this fix (the container image image does not match):
![szoter_annotated_image (1)](https://user-images.githubusercontent.com/43346/129470192-d817b392-9e70-44ac-a342-b8d62e6b25e0.jpeg)

With this fix:
![szoter_annotated_image](https://user-images.githubusercontent.com/43346/129470161-bc2980e1-7f9d-4db0-be85-070f9760daaa.jpeg)


