### PR TITLE
Explicitly set the docker-compose.yml filepath flag in helpers.sh

### DIFF
--- a/helpers.sh
+++ b/helpers.sh
@@ -1,6 +1,6 @@
 retrieve_webhook_secret() {
-  docker compose pull stripe > /dev/null 2>&1
-  docker compose run -T --rm stripe -c '/bin/stripe listen --api-key $STRIPE_SECRET_KEY --print-secret'
+  docker compose -f docker-compose.yml pull stripe > /dev/null 2>&1
+  docker compose -f docker-compose.yml run -T --rm stripe -c '/bin/stripe listen --api-key $STRIPE_SECRET_KEY --print-secret'
 }
 
 install_docker_compose_settings() {
@@ -8,9 +8,9 @@ install_docker_compose_settings() {
 
   install_docker_compose_settings_for_integration "NA" "NA" "NA"
 
-  docker compose run --entrypoint=/bin/sh runner -c true
-  docker cp . $(docker compose ps -qa runner | head -1):/work/
-  docker compose run --rm runner bundle install -j4
+  docker compose -f docker-compose.yml run --entrypoint=/bin/sh runner -c true
+  docker cp . $(docker compose -f docker-compose.yml ps -qa runner | head -1):/work/
+  docker compose -f docker-compose.yml run --rm runner bundle install -j4
 }
 
 configure_docker_compose_for_integration() {
@@ -23,12 +23,12 @@ configure_docker_compose_for_integration() {
 
   install_docker_compose_settings_for_integration "$sample" "$server_type" "$static_dir" "$server_image"
 
-  docker compose stop web || true
-  docker compose build web
+  docker compose -f docker-compose.yml stop web || true
+  docker compose -f docker-compose.yml build web
 
   # NOTE: On the CI, this function call is the only chance to copy the env file that contains proper values;
   #       maybe we should re-write ci.yml on each sample repository and remove this.
-  docker cp .env $(docker compose ps -qa runner | head -1):/work/${sample}/server/${server_type}/ || true
+  docker cp .env $(docker compose -f docker-compose.yml ps -qa runner | head -1):/work/${sample}/server/${server_type}/ || true
 }
 
 install_docker_compose_settings_for_integration() {
@@ -51,7 +51,7 @@ install_docker_compose_settings_for_integration() {
 }
 
 wait_web_server() {
-  docker compose exec -T -e TEST_URL="$1" runner bash -c 'curl -I --retry 30 --retry-delay 3 --retry-connrefused ${TEST_URL:-$SERVER_URL}'
+  docker compose -f docker-compose.yml exec -T -e TEST_URL="$1" runner bash -c 'curl -I --retry 30 --retry-delay 3 --retry-connrefused ${TEST_URL:-$SERVER_URL}'
 }
 
 server_langs_for_integration() {


### PR DESCRIPTION
### Summary

This PR updates the `helpers.sh` functions so that any `docker compose` invocation explicitly sets the path to the `docker-compose.yml` file.

This is more of a correctness fix- it's good to be as explicit in CI jobs as possible!

### Test Plan

It was admittedly tough to test this. We currently have actions disabled in the stripe-samples organization, and there are no actions in this repository.

I confirm that `docker-compose.yml` is the path we want, as it's set [here](https://github.com/stripe-samples/sample-ci/blob/main/helpers.sh#L49).

If you have anything else you'd like me to test here, let me know.