### PR TITLE
Use the latest stripe-cli image

### DIFF
--- a/docker/docker-compose-v2.yml
+++ b/docker/docker-compose-v2.yml
@@ -15,7 +15,7 @@ services:
       - gem:/usr/local/bundle
 
   stripe:
-    image: stripe/stripe-cli:v1.5.3
+    image: stripe/stripe-cli:latest
     init: true
     entrypoint: ['/bin/ash']
     command: ['-c', '/bin/stripe --api-key=$STRIPE_SECRET_KEY listen --forward-to http://web:4242/webhook']


### PR DESCRIPTION
Since older versions are not supported by the .Net examples, I updated the compose file to use the latest version. Other samples might fail because of this change (I will try to fix them later). In addition to this change, it seems we need to upgrade the default API version from the web UI to use the latest API version by default.

> Stripe.StripeException: Received event with API version 2020-08-27, but Stripe.net 44.8.0 expects API version 2024-04-10. We recommend that you create a WebhookEndpoint with this API version. Otherwise, you can disable this exception by passing `throwOnApiVersionMismatch: false` to `Stripe.EventUtility.ParseEvent` or `Stripe.EventUtility.ConstructEvent`, but be wary that objects may be incorrectly deserialized.